### PR TITLE
Make the Settings an Options Page

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "babel-loader": "^8.0.0-beta.2",
     "babel-minify-webpack-plugin": "^0.3.1",
     "babel-plugin-transform-react-jsx": "7.0.0-beta.3",
-    "bulma": "^0.6.2",
+    "bulma": "^0.7.0",
     "copy-webpack-plugin": "^4.5.1",
     "css-loader": "^0.28.7",
     "esm": "^3.0.21",

--- a/src/app/popup/index.jsx
+++ b/src/app/popup/index.jsx
@@ -5,9 +5,7 @@ import circleNotch from '@fortawesome/fontawesome-free-solid/faCircleNotch';
 
 import './styles.scss';
 
-import Settings from '../settings';
 import JiraIssues from '../jira-issues';
-import { get, set } from '../../chrome/storage';
 
 const undoneAssignedIssuesURL = ({ jiraSubdomain }) => `https://${jiraSubdomain}.atlassian.net/rest/api/2/search?fields=summary,status&jql=`
   + encodeURIComponent(`assignee=currentuser() AND status!="Done" ORDER BY updated DESC`);
@@ -25,11 +23,7 @@ class Popup extends React.Component {
     }
     this.fetchIssues = this.fetchIssues.bind(this);
     this.showSettings = this.showSettings.bind(this);
-    this.showIssues = this.showIssues.bind(this);
-    this.setSubdomain = this.setSubdomain.bind(this);
-    this.useTheOnlyFoundSubdomain = this.useTheOnlyFoundSubdomain.bind(this);
   }
-
 
   componentDidMount() {
     this.fetchIssues();
@@ -57,27 +51,10 @@ class Popup extends React.Component {
   }
 
   showSettings() {
-    this.setState(state => ({ mode: 'settings' }));
-  }
-
-  showIssues() {
-    this.setState(state => ({ mode: 'issues', issuesData: {} }), this.fetchIssues);
-  }
-
-  useTheOnlyFoundSubdomain() {
-    const { foundDomains } = this.props;
-    this.setSubdomain(foundDomains[0]);
-    this.showIssues();
-  }
-
-  setSubdomain(jiraSubdomain) {
-    this.setState({ jiraSubdomain }, () => {
-      this.props.setSubdomain(jiraSubdomain);
-    });
+    chrome.runtime.openOptionsPage();
   }
 
   render() {
-    const { foundDomains } = this.props;
     const {
       jiraSubdomain,
       mode,
@@ -88,14 +65,6 @@ class Popup extends React.Component {
 
     return (
       <div className="popup">
-        {mode === 'settings' &&
-          <Settings
-            foundDomains={foundDomains}
-            jiraSubdomain={jiraSubdomain}
-            onChange={this.setSubdomain}
-            done={this.showIssues}
-          />
-        }
         {mode === 'issues' &&
           <div className="jira-container panel">
             <p className='panel-heading'>
@@ -132,19 +101,7 @@ class Popup extends React.Component {
 
             {status === 'noSubdomain' &&
               <div className="message-container has-text-centered">
-                { foundDomains.length === 1 ?
-                  <div>
-                    <p className="notification">This extension needs your Jira subdomain to work. Is your organization at <strong>{foundDomains[0]}</strong>.atlassian.net?</p>
-                    <button
-                      className="button is-primary is-medium"
-                      onClick={this.useTheOnlyFoundSubdomain}
-                      style={{ width: '100% '}}>
-                      Yes, set it to {foundDomains[0]}
-                    </button>
-                    <a onClick={this.showSettings}>No, I'll enter it in Settings.</a>
-                  </div>
-                  : <span>Please enter your Jira subdomain under <a onClick={this.showSettings}>Settings</a>.</span>
-                }
+                <span>Please enter your Jira subdomain under <a onClick={this.showSettings}>Settings</a>.</span>
               </div>
             }
 

--- a/src/app/settings/components/settings.jsx
+++ b/src/app/settings/components/settings.jsx
@@ -3,20 +3,22 @@ import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import check from '@fortawesome/fontawesome-free-solid/faCheck';
 import times from '@fortawesome/fontawesome-free-solid/faTimes';
 import exclaimationTriangle from '@fortawesome/fontawesome-free-solid/faExclamationTriangle';
+import PropTypes from 'prop-types';
 
 const subdomainPlaceholder = 'Jira subdomain, e.g. twilio';
 
 const validationMessages = {
-  match: null,
+  match: "Looks good, detected a cookie at this subdomain",
   goodNoCookie: "Did not detect a cookie for this subdomain. Check for typos or you might not be logged in to Jira.",
-  bad: "The subdomain doesn't look right. If your organization URL is acme.atlassian.net, only enter acme.",
-  blank: "Please enter your subdomain"
+  bad: "The subdomain is invalid. If the organization URL is acme.atlassian.net, only enter acme.",
+  blank: "Please enter your Jira subdomain"
 };
 
 const validationIcons = {
   match: check,
   goodNoCookie: exclaimationTriangle,
-  bad: times
+  bad: times,
+  blank: null,
 };
 
 const validationColors = {
@@ -45,53 +47,118 @@ class Settings extends React.Component {
   constructor(props) {
     super(props);
 
+    this.state = {
+      pristine: true
+    };
+
     this.onChange = this.onChange.bind(this);
+    this.noLongerPristine = this.noLongerPristine.bind(this);
   }
 
   onChange(event) {
-    const { currentTarget: { value } } = event;
+    const { target: { value } } = event;
+
     this.props.onChange(value.trim());
+    this.noLongerPristine();
+  }
+
+  noLongerPristine() {
+    this.setState({ pristine: false });
+  }
+
+  currentMode(props, state) {
+    const { jiraSubdomain, foundDomains } = props;
+    const { pristine } = this.state;
+
+    switch (true) {
+      case !!jiraSubdomain: {
+        return 'settings';
+      }
+
+      case pristine && foundDomains.length == 1: {
+        return 'wizard';
+      }
+
+      default: {
+        return 'settings';
+      }
+    }
   }
 
   render() {
     const { jiraSubdomain, foundDomains, done } = this.props;
     const { icon, color, message } = validateSubdomain(jiraSubdomain, foundDomains);
+    const mode = this.currentMode(this.props, this.state);
 
     return (
       <div className="section settings">
-        <a onClick={done}>Back</a>
-        <h3 className="title">Settings</h3>
+        <h1 className="title">Jira Settings</h1>
 
-        <form onSubmit={done}>
-          <div className="field has-addons" style={{ flexWrap: 'wrap' }}>
-            <div className="control">
-              <a className="button is-static">
-                https://
-              </a>
+        { mode === 'settings' &&
+          <React.Fragment>
+            <form className="settings-form">
+              <div className="field has-addons" style={{ flexWrap: 'wrap' }}>
+                <div className="control">
+                  <a className="button is-static">
+                    https://
+                  </a>
+                </div>
+                <div className="control has-icons-right is-expanded">
+                  <input
+                    name="jiraSubdomain"
+                    type="text"
+                    className="input has-text-right"
+                    placeholder={subdomainPlaceholder}
+                    value={jiraSubdomain}
+                    onChange={this.onChange}
+                  />
+                  { icon &&
+                    <span className="icon is-right">
+                      <FontAwesomeIcon icon={icon} color={color} />
+                    </span>
+                  }
+                </div>
+                <div className="control is-expanded">
+                  <a className="button is-static">
+                    .atlassian.net
+                  </a>
+                </div>
+                { message &&
+                  <p className="help">{message}</p>
+                }
+              </div>
+
+              <button
+                onClick={window.close}
+                className="is-primary button is-medium close-button"
+              >Close this page</button>
+            </form>
+            <div className="muted">
+              <p><strong>Quick Start:</strong> Type <code>j</code>, then <code>tab</code>, type in a issue key (HSI-123) or free text to search. You must be logged in to Jira.</p>
+              <p><strong>How this works:</strong> After you entered the subdomain, this extension makes API requests to <code>your-domain.atlassian.net</code> using same origin cookies.</p>
+              <p>Permission to <code>*.atlassian.net</code> is required to retrieve the cookie for authentication. The extension does not manipulate the cookies in any other way.</p>
             </div>
-            <div className="control has-icons-right is-expanded">
-              <input
-                name="jiraSubdomain"
-                type="text"
-                className="input has-text-right"
-                placeholder={subdomainPlaceholder}
-                value={jiraSubdomain}
-                onChange={this.onChange}
-              />
-              <span className="icon is-right">
-                <FontAwesomeIcon icon={icon} color={color} />
-              </span>
+          </React.Fragment>
+        }
+
+        { mode === 'wizard' &&
+          <div className="wizard has-text-centered">
+            <div>
+              <p className='message'>
+                This extension needs your Jira subdomain to work.
+                Is your organization at <strong>{foundDomains[0]}</strong>.atlassian.net?
+              </p>
+              <button
+                className="button is-primary is-medium"
+                onClick={this.onChange}
+                value={foundDomains[0]}
+                style={{ width: '100% '}}>
+                Yes, set it to {foundDomains[0]}
+              </button>
+              <a onClick={this.noLongerPristine}>No, I'll enter it myself.</a>
             </div>
-            <div className="control is-expanded">
-              <a className="button is-static">
-                .atlassian.net
-              </a>
-            </div>
-            { message &&
-              <p className="help" style={{ width: '100%' }}>{message}</p>
-            }
           </div>
-        </form>
+        }
       </div>
     );
   }

--- a/src/background.js
+++ b/src/background.js
@@ -17,7 +17,7 @@ const escapeEntities = (text) => {
 
 const messages = {
   defaultPrompt: 'Type in a ticket number or free text to search for issues',
-  noSubdomain: 'Jira subdomain needs to be entered. Click on the extension icon to do so.',
+  noSubdomain: 'Jira subdomain needs to be entered. Click here or hit enter to open the Settings page',
   typeMore: 'Nothing yet. Keep typing :)'
 };
 

--- a/src/background.js
+++ b/src/background.js
@@ -79,6 +79,11 @@ const onInputChangedHandler = debounce((input, suggest) => {
 
 chrome.omnibox.onInputEntered.addListener((input, disposition) => {
   get(['jiraSubdomain']).then(({ jiraSubdomain }) => {
+    if (!jiraSubdomain) {
+      chrome.runtime.openOptionsPage();
+      return;
+    }
+
     if (input && !!input.trim() && jiraSubdomain) {
       const ticket = ticketMatch(input);
 

--- a/src/chrome/get-cookie-domains.js
+++ b/src/chrome/get-cookie-domains.js
@@ -1,8 +1,8 @@
 import { JIRA_DOMAIN } from '../config/constants';
 
 const exceptBasedomain = ({ domain }) =>
-  domain !== `.${JIRA_DOMAIN}` ||
-  domain !== `ecosystem.${JIRA_DOMAIN}` ||
+  domain !== `.${JIRA_DOMAIN}` &&
+  domain !== `ecosystem.${JIRA_DOMAIN}` &&
   domain !== '';
 
 export default async () => {

--- a/src/chrome/storage.js
+++ b/src/chrome/storage.js
@@ -7,3 +7,6 @@ export const set = object =>
   new Promise((resolve, reject) => {
     chrome.storage.sync.set(object, resolve)
   });
+
+  export const addOnChangedListener = listener =>
+    chrome.storage.onChanged.addListener(listener);

--- a/src/options.html
+++ b/src/options.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
+    <title>Jira: Settings</title>
+  </head>
+  <body>
+    <div id="options" class="options-wrapper">
+    </div>
+  </body>
+</html>

--- a/src/options.js
+++ b/src/options.js
@@ -1,0 +1,34 @@
+import './options.scss';
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import { get, set, addOnChangedListener } from './chrome/storage';
+import getCookieDomains from './chrome/get-cookie-domains';
+
+import Settings from './app/settings';
+
+const root = document.getElementById('options');
+
+const setSubdomain = jiraSubdomain =>
+  set({ jiraSubdomain }, null);
+
+const render = () =>
+  Promise.all([get(['jiraSubdomain']), getCookieDomains()]).then(([{ jiraSubdomain }, foundDomains]) => {
+    ReactDOM.render(
+      <Settings
+        jiraSubdomain={jiraSubdomain}
+        foundDomains={foundDomains}
+        onChange={setSubdomain}
+      />,
+      root
+    )
+  });
+
+addOnChangedListener(({ jiraSubdomain }) => {
+  if (jiraSubdomain) {
+    render();
+  }
+});
+
+render();

--- a/src/options.scss
+++ b/src/options.scss
@@ -1,0 +1,45 @@
+@import "~bulma/sass/utilities/_all";
+@import "~bulma/sass/base/_all";
+@import "~bulma/sass/elements/form";
+@import "~bulma/sass/elements/button";
+@import "~bulma/sass/elements/title";
+@import "~bulma/sass/elements/icon";
+
+.options-wrapper {
+  margin: 3rem auto;
+  border: 1px solid #EEE;
+  border-radius: 3px;
+  width: 500px;
+  min-height: 400px;
+  padding: 1.5rem;
+
+  .title {
+    text-align: center;
+  }
+
+  .help {
+    width: 100%;
+  }
+}
+
+.message {
+  background-color: whitesmoke;
+  border-radius: 4px;
+  padding: 1.25rem 2.5rem 1.25rem 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.muted {
+  margin-top: 1rem;
+  background-color: whitesmoke;
+  padding: 1.25rem 2.5rem 1.25rem 1.5rem;
+  font-size: 0.8rem;
+  p {
+    margin-bottom: 0.5rem;
+  }
+}
+
+.close-button {
+  text-align: center;
+  width: 100%;
+}

--- a/src/popup.jsx
+++ b/src/popup.jsx
@@ -10,18 +10,11 @@ import Popup from './app/popup';
 const root = document.createElement('div');
 document.body.append(root);
 
-const setSubdomain = jiraSubdomain =>
-  set({ jiraSubdomain }, null);
-
 setTimeout(() => {
   Promise.all([get(['jiraSubdomain']), getCookieDomains()])
     .then(([{ jiraSubdomain }, foundDomains]) => {
       ReactDOM.render(
-        <Popup
-          jiraSubdomain={jiraSubdomain}
-          foundDomains={foundDomains}
-          setSubdomain={setSubdomain}
-        />,
+        <Popup jiraSubdomain={jiraSubdomain} />,
         root
       )
     });

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -13,6 +13,7 @@
     "64": "jira64.png",
     "128": "jira128.png"
   },
+  "options_page": "options.html",
   "browser_action": {
     "default_title": "Issues",
     "default_popup": "popup.html"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,6 +22,13 @@ const popupPage = new HtmlWebpackPlugin({
   filename: `${extensionDirectory}/popup.html`
 });
 
+const optionsPage = new HtmlWebpackPlugin({
+  title: 'Jira',
+  chunks: ['options'],
+  template: './src/options.html',
+  filename: `${extensionDirectory}/options.html`
+});
+
 const cssRule = {
   test: /\.scss$/,
   use: ExtractTextPlugin.extract({
@@ -53,6 +60,7 @@ const jsRule = {
 const plugins = [
   backgroundPage,
   popupPage,
+  optionsPage,
   new CopyWebpackPlugin([
     { from: './static/manifest.json', to: extensionDirectory },
     { from: './static/images/jira*.png', to: extensionDirectory, flatten: true }
@@ -78,7 +86,8 @@ module.exports = {
   },
   entry: {
     popup: './src/popup.jsx',
-    background: './src/background.js'
+    background: './src/background.js',
+    options: './src/options.js'
   },
   resolve: {
     extensions: ['.js', '.jsx', '.mjs']

--- a/yarn.lock
+++ b/yarn.lock
@@ -1341,9 +1341,9 @@ builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
 
-bulma@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.6.2.tgz#f4b1d11d5acc51a79644eb0a2b0b10649d3d71f5"
+bulma@^0.7.0:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.7.1.tgz#73c2e3b2930c90cc272029cbd19918b493fca486"
 
 bytes@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## What's up? 

Chrome extensions have this option to use the Options UI, which is basically just a page you can programatically activate for extension options. 

## Why is this better than the Popup? 
- The options page can easily be activated by using `chrome.runtime.openOptionsPage()` from anywhere. Makes it easy for example, for the omnibox to trigger the page if there are subdomain errors. It's not possible to trigger the Popup programatically. It's also weird to trigger the popup even if Chrome allowed it.
- From current user feedback, it seems that no one really uses the Popup, so this paves the way to killing it eventually. 

<img width="555" alt="screen shot 2018-04-26 at 9 47 54 am" src="https://user-images.githubusercontent.com/1251946/39309860-f8a1bf64-4936-11e8-94fb-e8b7e20e08c8.png">
