### PR TITLE
Better matching and a duplicate injection bug fix

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -30,16 +30,18 @@ const getTicketMatches = () => {
 const initializeDOM = e => {
   const navbar = document.querySelector(pullRequestNavbarContainerSelector);
   if(!navbar) { return; }
-  const container = document.getElementById(containerID);
-  if(container) { return; }
+  if(document.getElementById(containerID)) { return; }
+
+  const container = document.createElement('div');
+  container.id = containerID;
+  navbar.insertAdjacentElement('beforebegin', container);
 
   get(['jiraSubdomain']).then(({ jiraSubdomain }) => {
     if(!jiraSubdomain) { return; }
     const ticketMatches = getTicketMatches();
     const jiraClient = getClientInstance(jiraSubdomain);
-    const container = document.createElement('div');
-    container.id = containerID;
-    navbar.insertAdjacentElement('beforebegin', container);
+
+    console.debug('injecting ', container.id);
 
     injectJiraBarAboveConversation(container, { jiraClient, ticketMatches});
   });

--- a/src/github.js
+++ b/src/github.js
@@ -41,8 +41,6 @@ const initializeDOM = e => {
     const ticketMatches = getTicketMatches();
     const jiraClient = getClientInstance(jiraSubdomain);
 
-    console.debug('injecting ', container.id);
-
     injectJiraBarAboveConversation(container, { jiraClient, ticketMatches});
   });
 }

--- a/src/utilities/regex.js
+++ b/src/utilities/regex.js
@@ -1,1 +1,1 @@
-export const pullRequestURL = /pull\/\d+$/;
+export const pullRequestURL = /pull\/\d+/;

--- a/tests/utilities/regex.test.mjs
+++ b/tests/utilities/regex.test.mjs
@@ -1,0 +1,20 @@
+import { pullRequestURL } from '../../src/utilities/regex';
+import test from 'tape';
+
+test('matches github pull request with further segments', t => {
+  t.plan(1);
+
+  t.true(pullRequestURL.test('https://github.com/daemonsy/jira/pull/15/files'));
+});
+
+test('matches github pull request with hashes', t => {
+  t.plan(1);
+
+  t.true(pullRequestURL.test('https://github.com/daemonsy/jira/pull/15/files#diff-1d37e48f9ceff6d8030570cd36286a61R41'));
+});
+
+test('matches github pull request with queries', t => {
+  t.plan(1);
+
+  t.true(pullRequestURL.test('https://github.com/daemonsy/jira/pull/15?test=test'));
+});


### PR DESCRIPTION
## What's up? 

This started as a fix for #16. 

- Once the regex is relaxed for subpaths, queries and hashes, I realized there were multiple racing injections while navigating the tab bar.
- This is most likely because of pjax. Both the background `executeScript` and `github.js` content script itself were racing. 
- Background script: Used a callback to prevent double execution (pjax tabs seem to cause the same event to fire twice)
- In the CS: Moved the container injection out of the async part. 
